### PR TITLE
Fix undefined var

### DIFF
--- a/coffee/sync-exec.coffee
+++ b/coffee/sync-exec.coffee
@@ -4,7 +4,7 @@ fs = require 'fs'
 
 tmp_dir = '/tmp'
 for name in ['TMPDIR', 'TMP', 'TEMP']
-  tmp_dir = tmp.split('/')[0] if (dir = process.env[name])?
+  tmp_dir = dir.replace /\/$/, '' if (dir = process.env[name])?
 
 create_pipes = ->
   until created

--- a/js/sync-exec.js
+++ b/js/sync-exec.js
@@ -12,7 +12,7 @@
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     name = _ref[_i];
     if ((dir = process.env[name]) != null) {
-      tmp_dir = tmp.split('/')[0];
+      tmp_dir = dir.replace(/\/$/, '');
     }
   }
 


### PR DESCRIPTION
Hi,
Just tried sync-exec and got an error: `tmp` var is undefined.
So I replaced it with `dir` and added a regexp to remove trailing slash.
