### PR TITLE
Return real status codes rather than just 0/1

### DIFF
--- a/coffee/sync-exec.coffee
+++ b/coffee/sync-exec.coffee
@@ -98,7 +98,7 @@ module.exports = (cmd, max_wait, options) ->
 
   dir = create_pipes()
   cmd = '((((' + cmd + ' > ' + dir + '/stdout 2> ' + dir + '/stderr ) ' +
-        '&& echo 0 > ' + dir + '/status) || echo 1 > ' + dir + '/status) &&' +
+        '&& echo $? > ' + dir + '/status) || echo $? > ' + dir + '/status) &&' +
         ' echo 1 > ' + dir + '/done) || echo 1 > ' + dir + '/done'
   child_process.exec cmd, options, ->
 

--- a/js/sync-exec.js
+++ b/js/sync-exec.js
@@ -123,7 +123,7 @@
     }
     delete options.timeout;
     dir = create_pipes();
-    cmd = '((((' + cmd + ' > ' + dir + '/stdout 2> ' + dir + '/stderr ) ' + '&& echo 0 > ' + dir + '/status) || echo 1 > ' + dir + '/status) &&' + ' echo 1 > ' + dir + '/done) || echo 1 > ' + dir + '/done';
+    cmd = '((((' + cmd + ' > ' + dir + '/stdout 2> ' + dir + '/stderr ) ' + '&& echo $? > ' + dir + '/status) || echo $? > ' + dir + '/status) &&' + ' echo 1 > ' + dir + '/done) || echo 1 > ' + dir + '/done';
     child_process.exec(cmd, options, function() {});
     return read_pipes(dir, max_wait);
   };


### PR DESCRIPTION
One of the notable differences between your lovely "sync-exec" module and the Node 0.12 core `child_process.execSync` is that the latter will include the real exit status codes (in the case of an error/failure, anyway) whereas the former's exit status codes will always be either `0` (success) or `1` (any sort of failure).

Why not return the return status codes instead? :+1: