### PR TITLE
Use `Date.now()` instead of verbose `(new Date).getTime()`

### DIFF
--- a/coffee/sync-exec.coffee
+++ b/coffee/sync-exec.coffee
@@ -8,11 +8,11 @@ for name in ['TMPDIR', 'TMP', 'TEMP']
 
 
 timeout = (limit, msg) ->
-  if (new Date).getTime() > limit
+  if Date.now() > limit
     throw new Error msg
 
 create_pipes = ->
-  t_limit = (new Date).getTime() + 1000 # 1 second timeout
+  t_limit = Date.now() + 1000 # 1 second timeout
 
   until created
     try
@@ -24,7 +24,7 @@ create_pipes = ->
 
 
 read_pipes = (dir, max_wait) ->
-  t_limit = (new Date).getTime() + max_wait
+  t_limit = Date.now() + max_wait
 
   until read
     try
@@ -56,7 +56,7 @@ proxy = (cmd, max_wait, options) ->
   stdout = stderr = ''
   status = 0
 
-  t0 = (new Date).getTime()
+  t0 = Date.now()
 
   orig_write = process.stderr.write
   process.stderr.write = ->
@@ -65,7 +65,7 @@ proxy = (cmd, max_wait, options) ->
     process.stderr.write = orig_write
   catch err
     process.stderr.write = orig_write
-    if err.signal is 'SIGTERM' and t0 <= (new Date).getTime() - max_wait
+    if err.signal is 'SIGTERM' and t0 <= Date.now() - max_wait
       throw new Error 'Timeout'
     {stdout, stderr, status} = err
 

--- a/js/sync-exec.js
+++ b/js/sync-exec.js
@@ -17,14 +17,14 @@
   }
 
   timeout = function(limit, msg) {
-    if ((new Date).getTime() > limit) {
+    if (Date.now() > limit) {
       throw new Error(msg);
     }
   };
 
   create_pipes = function() {
     var created, t_limit;
-    t_limit = (new Date).getTime() + 1000;
+    t_limit = Date.now() + 1000;
     while (!created) {
       try {
         dir = tmp_dir + '/sync-exec-' + Math.floor(Math.random() * 1000000000);
@@ -38,7 +38,7 @@
 
   read_pipes = function(dir, max_wait) {
     var deleted, j, len1, pipe, read, ref1, result, t_limit;
-    t_limit = (new Date).getTime() + max_wait;
+    t_limit = Date.now() + max_wait;
     while (!read) {
       try {
         if (fs.readFileSync(dir + '/done').length) {
@@ -76,7 +76,7 @@
     options.timeout = max_wait;
     stdout = stderr = '';
     status = 0;
-    t0 = (new Date).getTime();
+    t0 = Date.now();
     orig_write = process.stderr.write;
     process.stderr.write = function() {};
     try {
@@ -85,7 +85,7 @@
     } catch (_error) {
       err = _error;
       process.stderr.write = orig_write;
-      if (err.signal === 'SIGTERM' && t0 <= (new Date).getTime() - max_wait) {
+      if (err.signal === 'SIGTERM' && t0 <= Date.now() - max_wait) {
         throw new Error('Timeout');
       }
       stdout = err.stdout, stderr = err.stderr, status = err.status;


### PR DESCRIPTION
Use `Date.now()` instead of verbose `(new Date).getTime()`.

It's _waaaaaaay_ more concise [**and** technically faster]. :+1: