### PR TITLE
Use the SPDX identifier for GPL version 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "status"
   ],
   "author": "Greg Varsanyi",
-  "license": "GNU GPLv2",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/gvarsanyi/sync-exec/issues"
   },


### PR DESCRIPTION
This tiny pull request replaces `GNU GPLv2` with `GPL-2.0`, the [SPDX-standard license identifier for the GNU General Public License version 2.0](http://spdx.org/licenses), in `package.json`. [npm's metadata guidelines](https://docs.npmjs.com/files/package.json#license) ask for the SPDX identifier, in part to make it much easier to discover and verify package licenses with automated tools.

Thanks so much for sync-exec. In case you haven't noticed, it cracked [the 1,000 most-depended-upon npm packages today](http://npm1k.org)!