### PR TITLE
Use mkdirSync in create-pipes

### DIFF
--- a/coffee/lib/create-pipes.coffee
+++ b/coffee/lib/create-pipes.coffee
@@ -19,7 +19,7 @@ module.exports = ->
   until created
     try
       dir = tmp_dir + '/sync-exec-' + Math.floor Math.random() * 1000000000
-      fs.mkdir dir
+      fs.mkdirSync dir
       created = true
 
     timeout t_limit, 'Can not create sync-exec directory'

--- a/js/lib/create-pipes.js
+++ b/js/lib/create-pipes.js
@@ -20,7 +20,7 @@
     while (!created) {
       try {
         dir = tmp_dir + '/sync-exec-' + Math.floor(Math.random() * 1000000000);
-        fs.mkdir(dir);
+        fs.mkdirSync(dir);
         created = true;
       } catch (_error) {}
       timeout(t_limit, 'Can not create sync-exec directory');


### PR DESCRIPTION
Replace <code>mkdir</code> with <code>mkdirSync</code> in <code>create-pipes</code>, so error thrown (e.g. on directory existed) would be properly caught.
Currently on directory collision, the asynchronous <code>mkdir</code>'s error would not be caught and <code>sync-exec</code> would erroneously assumed the directory to exist, which could result in various error such as hanging.

I know with <code>execSync</code> inherently in Node 0.12 the wise thing to do is probably to move onto that. But for various reasons I'm currently stuck with Node 0.10 and <code>sync-exec</code> is what I'm using to polyfill <code>execSync</code>.
@gvarsanyi would you help review this PR?